### PR TITLE
fix: set ruamel.yaml version to 0.16.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click==6.7
 ansible_vault==1.1.1
 ansible==2.5.3
-ruamel.yaml==0.15.35
+ruamel.yaml==0.16.12


### PR DESCRIPTION
Installing ruamel.yaml version 0.15.35 fails, bumping to latest version
resolves the issue and installiation of python-ansible-vault-rekey via
pip works.

Fixes #352.